### PR TITLE
Add method to ease adding of transaction channels together

### DIFF
--- a/src/Enums/TransactionChannel.php
+++ b/src/Enums/TransactionChannel.php
@@ -15,4 +15,11 @@ enum TransactionChannel: int
     case CARDS_ONLY = 4096;
     case BLIK = 8192;
     case ALL_EXCEPT_BLIK = 16384;
+
+    public static function multiple(array $channels): int
+    {
+        return array_sum(
+            array_map(fn (TransactionChannel $channel): int => $channel->value, $channels)
+        );
+    }
 }

--- a/tests/Enums/TransactionChannelTest.php
+++ b/tests/Enums/TransactionChannelTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Przelewy24\Tests\Enums;
+
+use PHPUnit\Framework\TestCase;
+use Przelewy24\Enums\TransactionChannel;
+
+class TransactionChannelTest extends TestCase
+{
+    public function testMultiple(): void
+    {
+        $multiple = TransactionChannel::multiple([
+            TransactionChannel::CARDS,
+            TransactionChannel::TRADITIONAL_TRANSFER,
+            TransactionChannel::BLIK,
+        ]);
+
+        $this->assertEquals(1 + 4 + 8192, $multiple);
+    }
+}


### PR DESCRIPTION
Channels can be combined using:

```php
use Przelewy24\Enums\TransactionChannel;

$multiple = TransactionChannel::multiple([
    TransactionChannel::CARDS,
    TransactionChannel::TRADITIONAL_TRANSFER,
    TransactionChannel::BLIK,
]);

var_dump($multiple);
```

```
int(8197)
```
